### PR TITLE
Add support for Go 1.13 error chains

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -159,6 +159,9 @@ type withStack struct {
 
 func (w *withStack) Cause() error { return w.error }
 
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
+
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -240,6 +243,9 @@ type withMessage struct {
 
 func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {

--- a/go1.13_compat_test.go
+++ b/go1.13_compat_test.go
@@ -1,0 +1,18 @@
+// +build go1.13
+
+package errors_test
+
+import (
+	stdlib_errors "errors"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestErrorChainCompat(t *testing.T) {
+	err := stdlib_errors.New("error that gets wrapped")
+	wrapped := errors.Wrap(err, "wrapped up")
+	if !stdlib_errors.Is(wrapped, err) {
+		t.Errorf("Wrap does not support Go 1.13 error chains")
+	}
+}


### PR DESCRIPTION
Go 1.13 adds support for error chains to the standard libary's errors
package. The new standard library functions require an Unwrap method to
be provided by an error type. This change adds a new Unwrap method
(identical to the existing Cause method) to the unexported error types.